### PR TITLE
Add engineer load indicators.

### DIFF
--- a/lib/boardie.rb
+++ b/lib/boardie.rb
@@ -100,6 +100,12 @@ module Boardie
       ws.each do |stream|
         @workstreams << stream.workstream
       end
+
+      oe = Ticket.all(:fields => [:assigned_to], :unique => true, :assigned_to.not => nil, :assigned_to.not => "")
+      @engineers = []
+      oe.each do |engine|
+        @engineers << engine.assigned_to
+      end
     end
 
     def create_record(issue)

--- a/lib/views/index.erb
+++ b/lib/views/index.erb
@@ -1,10 +1,29 @@
-<table class="table table-bordered">
-<tr>
-   <% @workstreams.sort.each do |stream| %><td><a href="<%= url('/stream/'+stream) %>"><%= stream %></a></td> <% end %>
-</tr>
-</table>
+</br>
 
-<br />
+<table class="table table-bordered">
+  <thead>
+    <tr>
+    <% @engineers.sort.each do |engine| %>
+      <th><center><%= engine %></center></th>
+    <% end %>
+    </tr>
+  </thead>
+</tbody>
+    <tr>
+    <% @engineers.sort.each do |engine| %>
+      <% owned = (@issues.find_all do |issue| issue.assigned_to == engine end).count %>
+      <% case
+       when owned < 4
+         color = 'label-success'
+       when owned == 4, owned == 5
+         color = 'label-warning'
+       when owned > 5
+        color = 'label-important'
+      end %>
+      <td class="td <%= color %>"><center><%= "#{owned}" %></center></td>
+    <% end %>
+    </tr>
+</table>
 
 <table class="table table-bordered">
 <thead>

--- a/lib/views/layout.erb
+++ b/lib/views/layout.erb
@@ -41,6 +41,17 @@
               <li class="active"><a href="/">Home</a></li>
             </ul>
           </div><!--/.nav-collapse -->
+          <ul class="nav">
+            <div class="btn-group">
+              <a class="btn btn-inverse dropdown-toggle" data-toggle="dropdown" href="#">
+                Streams
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <% @workstreams.sort.each do |stream| %><a href="<%= url('/stream/'+stream) %>"><%= stream %></a><% end %>
+              </ul>
+            </div>
+          </ul>
         </div>
       </div>
     </div>

--- a/lib/views/stream.erb
+++ b/lib/views/stream.erb
@@ -1,9 +1,3 @@
-<table class="table table-bordered">
-<tr>
-   <% @workstreams.sort.each do |stream| %><td><a href="<%= url('/stream/'+stream) %>"><%= stream %></a></td> <% end %>
-</tr>
-</table>
-
 <br />
 
 <div id="container">


### PR DESCRIPTION
Added green, yellow, and red load indicators that indicate how many
  projects a given engineer are currently invovled in.  To unclutter the
  top after this addition I moved streams into a bottom edge nav bar.
